### PR TITLE
Converting picture to minecraft compatible buffer

### DIFF
--- a/src/mapColors.js
+++ b/src/mapColors.js
@@ -29,18 +29,17 @@ export default class {
 
 	/**
 	 * Take an image and return a buffer array of minecraft compatible colors
-	 * @param {String} path
+	 * @param {String} path the image path (can be an url)
 	 * @returns an array [ { id, r, g, b } ]
 	 */
 	static async fromImage(path) {
 		const img = await pixels(path)
 		const [width, height] = img.shape
 		const result = []
-		for (let x = 0; x < width; x++) {
+		for (let x = 0; x < width; x++)
 			for (let y = 0; y < height; y++) {
 				result.push(this.nearestMatch(img.get(x, y, 0), img.get(x, y, 1), img.get(x, y, 2)))
 			}
-		}
 		return result
 	}
 


### PR DESCRIPTION
### Related #1 

test with [@PrismarineJS/node-minecraft-protocol](https://github.com/PrismarineJS/node-minecraft-protocol)

```js
import MapColor from '@aresrpg/aresrpg-map-colors'

const size = 128
const datas = await MapColor.fromImage('https://i.imgur.com/h8g7SEf.jpg')
const buffer = datas.map(({ id }) => id)

client.write('map', {
	itemDamage: 0,
	scale: 4,
	trackingPosition: false,
	icons: [],
	columns: size - 1,
	rows: size - 1,
	x: 0,
	y: 0,
	data: Buffer.from(buffer),
})
```